### PR TITLE
Fixes to help approval on extensions.gnome.org

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,11 +1,13 @@
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+
+const {GObject, Shell, St} = imports.gi;
 const Main = imports.ui.main
 const PanelMenu = imports.ui.panelMenu
 const PopupMenu = imports.ui.popupMenu
-const St = imports.gi.St
-const Lang = imports.lang
-const Meta = imports.gi.Meta
-const Shell = imports.gi.Shell
 const Util = imports.misc.util
+
+const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
+const _ = Gettext.gettext;
 
 function _aboutThisDistro() {
 	Util.spawn(['gnome-control-center', 'info-overview'])
@@ -67,41 +69,37 @@ function _extensions() {
 // }
 
 
-const MenuButton = new Lang.Class({
-    Name: "MenuButton",
-    Extends: PanelMenu.Button,
-
-    _init: function () {
-        this.parent(null, "MenuButton")
+var MenuButton = GObject.registerClass(class FedoraMenu_MenuButton 
+	extends PanelMenu.Button {
+    _init() {
+		super._init(0.0, "MenuButton");
 
         // Icon
         this.icon = new St.Icon({
             style_class: 'menu-button'
         })
-        this.actor.add_actor(this.icon)
+        this.add_actor(this.icon)
 
         // Menu
-	this.item1 = new PopupMenu.PopupMenuItem('About My System')
-	this.item2 = new PopupMenu.PopupMenuItem('System Preferences')
-	this.item3 = new PopupMenu.PopupMenuItem('Software Center')
-	this.item4 = new PopupMenu.PopupMenuItem('Activities')
-        this.item5 = new PopupMenu.PopupMenuItem('Terminal')
-	this.item6 = new PopupMenu.PopupMenuItem('Extensions')
-	
-					
-	this.item1.connect('activate', Lang.bind(this, _aboutThisDistro))
-	this.item2.connect('activate', Lang.bind(this, _systemPreferences))
-	this.item3.connect('activate', Lang.bind(this, _appStore))
-	this.item4.connect('activate', Lang.bind(this, _missionControl))
-	this.item5.connect('activate', Lang.bind(this, _terminal))
-        this.item6.connect('activate', Lang.bind(this, _extensions))
-        this.menu.addMenuItem(this.item1)
-	this.menu.addMenuItem(this.item2)
-	this.menu.addMenuItem(this.item3)
-	this.menu.addMenuItem(this.item4)
-	this.menu.addMenuItem(this.item5)
-
-		}
+		this.item1 = new PopupMenu.PopupMenuItem(_('About My System'))
+		this.item2 = new PopupMenu.PopupMenuItem(_('System Preferences'))
+		this.item3 = new PopupMenu.PopupMenuItem(_('Software Center'))
+		this.item4 = new PopupMenu.PopupMenuItem(_('Activities'))
+		this.item5 = new PopupMenu.PopupMenuItem(_('Terminal'))
+		this.item6 = new PopupMenu.PopupMenuItem(_('Extensions'))
+			
+		this.item1.connect('activate', () => _aboutThisDistro())
+		this.item2.connect('activate', () => _systemPreferences())
+		this.item3.connect('activate', () => _appStore())
+		this.item4.connect('activate', () => _missionControl())
+		this.item5.connect('activate', () => _terminal())
+		this.item6.connect('activate', () => _extensions())
+		this.menu.addMenuItem(this.item1)
+		this.menu.addMenuItem(this.item2)
+		this.menu.addMenuItem(this.item3)
+		this.menu.addMenuItem(this.item4)
+		this.menu.addMenuItem(this.item5)
+	}
 })
 
 function init() {
@@ -117,13 +115,13 @@ function enable() {
 	Main.panel.addToStatusArea('menuButton', indicator, 0, 'left')
 
 	// hide
-	Main.panel.statusArea['menuButton'].actor.visible = false
+	Main.panel.statusArea['menuButton'].visible = false
 
 	// change icon
 	//Main.panel.statusArea['menuButton'].icon.icon_name = "appointment-soon-symbolic"
 
 	// show
-	Main.panel.statusArea['menuButton'].actor.visible = true
+	Main.panel.statusArea['menuButton'].visible = true
 }
  
 function disable() {


### PR DESCRIPTION
-Remove Lang in favor of GObject
-Use Gettext for string translations
-Remove deprecated 'actor' call