### PR TITLE
fixed make file

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,3 @@
 install:
 	mkdir -p /home/$(USER)/.local/share/gnome-shell/extensions/fedoramenu@tofu
-	cp -r ../fedoramenu/* /home/$(USER)/.local/share/gnome-shell/extensions/fedoramenu@tofu
+	cp -r ./* /home/$(USER)/.local/share/gnome-shell/extensions/fedoramenu@tofu


### PR DESCRIPTION
Forgot to fix this in the previous PR.

First I downloaded the file as zip and so the file name was fedoramenu-main, so the make install failed since the folder name was hardcoded as just fedoramenu. So, just provided a generic way to copy the file.